### PR TITLE
:computer: conditionally prevents key events default behaviour

### DIFF
--- a/src/scene/Camera.js
+++ b/src/scene/Camera.js
@@ -205,7 +205,7 @@ export default class Camera {
    * @event document~keypress
    */
   keyPressHandler = (e) => {
-    e.preventDefault()
+    !this.paused && e.preventDefault()
     if (this.paused) return false
     if (e.key.toLowerCase() === 'w' || e.keyCode === 'ArrowUp')
       this.movingTo.front = true
@@ -225,7 +225,7 @@ export default class Camera {
    * @event document~keyup
    */
   keyUpHandler = (e) => {
-    e.preventDefault()
+    !this.paused && e.preventDefault()
     if (this.paused) return false
     if (e.key.toLowerCase() === 'w' || e.keyCode === 'ArrowUp')
       this.movingTo.front = false

--- a/src/scene/Scene.js
+++ b/src/scene/Scene.js
@@ -153,7 +153,7 @@ export default class Scene {
    * @event document~keypress
    */
   keyPressHandler = (e) => {
-    e.preventDefault()
+    this.paused && e.preventDefault()
     if (e.key.toLowerCase() === 'Escape') {
       this.paused = true
     }


### PR DESCRIPTION
This PR provides:

+ fix for key events handling

**Reason:** users wouldn't be able to type in characters in any form, key events default behaviour were being pevented